### PR TITLE
Perform function name inference for public fields

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -323,11 +323,15 @@ emu-example pre {
       1. Let _lex_ be the Lexical Environment of the running execution context.
       1. Let _initializer_ be FunctionCreate(~Method~, ~empty~, |Initializer|, _lex_, *true*).
       1. Perform MakeMethod(_initializer_, _homeObject_).
-    1. Else, let _initializer_ be ~empty~.
+      1. Let _isAnonymousFunctionDefinition_ be IsAnonymousFunctionDefinition(|Initializer|).
+    1. Else,
+      1. Let _initializer_ be ~empty~.
+      1. Let _isAnonymousFunctionDeclaration_ be *false*.
     1. Return Record {
          [[Name]]: _fieldName_, 
          [[Initializer]]: _initializer_,
          [[Static]]: _isStatic_,
+         [[IsAnonymousFunctionDefinition]]: _isAnonymousFunctionDefinition_,
        }.
   </emu-alg>
 </emu-clause>
@@ -356,9 +360,13 @@ emu-example pre {
     1. If _initializer_ is not ~empty~, then
       1. Let _initValue_ be ? Call(_initializer_, _receiver_).
     1. Else, let _initValue_ be *undefined*.
-    1. If _name_ is a Private Name,
-      1. Perform ? PrivateFieldAdd(_name_, _O_, _initialValue_).
-    1. Otherwise, _name_ is a property key,
+    1. If _fieldName_ is a Private Name,
+      1. Perform ? PrivateFieldAdd(_fieldName_, _O_, _initialValue_).
+    1. Else,
+      1. NOTE: _fieldName_ is a property key.
+      1. If _fieldRecord_.[[IsAnonymousFunctionDefinition]] is *true*, then
+        1. Let _hasNameProperty_ be ? HasOwnProperty(_initValue_, `"name"`).
+        1. If _hasNameProperty_ is *false*, perform SetFunctionName(_initValue_, _propKey_).
       1. Let _desc_ be PropertyDescriptor{
            [[Configurable]]: *false*,
            [[Enumerable]]: *true*,


### PR DESCRIPTION
Fixes https://github.com/tc39/proposal-class-public-fields/issues/48.

Also a couple of minor editorial corrections: `name` appears to have been used in place of `fieldName` in a few places in `DefineField`, and an `otherwise` is switched to a `else` & `NOTE`.

A couple of notes:

1. FNI is only performed for public fields. As an alternative, they could be given a name like `#foo`, similar to how `({[Symbol('bar')] : function(){}})` creates a function with name `[bar]`.
2. This is a little awkward because `IsAnonymousFunctionDefinition` operates on parse nodes rather than values, and the parse node for the initializer is not available to `DefineMethod`. So its result needs to be passed around in the field Record.