### PR TITLE
Normative: Ban static private field declarations

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -156,6 +156,9 @@ emu-example pre {
       <li>
         It is a Syntax Error if PropName of |FieldDefinition| is `"prototype"` or `"constructor"`.
       </li>
+      <li>
+        It is a Syntax Error if |FieldDefinition| is <emu-grammar>FieldDefinition: ClassElementName Initializer?</emu-grammar> with <emu-grammar>ClassElementName: PrivateName</emu-grammar>.
+      </li>
     </ul>
 
     <emu-grammar>ClassElement : FieldDefinition `;`</emu-grammar>


### PR DESCRIPTION
In order to prevent unintuitive behavior from the behavior of static
private fields, make them syntax errors.

This is one aspect of #43