### PR TITLE
Fix ASI error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ class C {
   static #y;
   static [a];
   
-  z
-  #w = 2
+  z;
+  #w = 2;
   [b];
 }
 ```


### PR DESCRIPTION
The one after the `2` is necessary; for consistency, just put them all in.