### PR TITLE
Normative: End `this` TDZ before running initializers

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -697,8 +697,9 @@ emu-example pre {
       1. Let _thisER_ be GetThisEnvironment( ).
       1. Let _F_ be _thisER_.[[FunctionObject]].
       1. Assert: _F_ is an ECMAScript function object.
+      1. <del>Return<del><ins>Perform</ins> ? _thisER_.BindThisValue(_result_).
       1. <ins>Perform ? InitializeInstanceFields(_result_, _F_).</ins>
-      1. Return ? _thisER_.BindThisValue(_result_).
+      1. <ins>Return _result_.</ins>
     </emu-alg>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
Previously, the TDZ of `this` in a subclass constructor ended when
the `super()` call was entirely finished. However, `this` is visible
as not being in TDZ running initializers. For example:

{
  let f;
  class A extends (class {}) {
    x = (this, f());
    constructor() { f = () => this; super(); }
  };
  new A;
}

Previously, `f()` would lead to a ReferenceError in this case, while
`this` would evaluate to the new instance under construction.

This patch tweaks the TDZ to end a little bit sooner, so that `this`
is defined inside of the constructor's scope *before* the initializers
are run. In the above example, there would be no ReferenceError
under the semantics in this patch.

Thanks to Caitlin Potter, Kevin Gibbons and Jordan Harband for
contributing to the discussion that led to this change.