### PR TITLE
Normative: Thread through lexically scoped private names

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -218,18 +218,6 @@ emu-example pre {
     For all other grammatical productions, recurse on subexpressions/substatements, passing in the _names_ of the caller. If all pieces return *true*, then return *true*. If any returns *false*, return *false*.
   <emu-note type=editor>TODO: Elaborate the preceding paragraph with spec text inserted in each relevant place</emu-note>
   </emu-clause>
-<emu-clause id="sec-performeval">
-  <h1>Runtime Semantics: PerformEval ( _x_, _evalRealm_, _strictCaller_, _direct_ )</h1>
-  <emu-clause id="sec-performeval-rules-in-initializer">
-    <h1>Additional Early Error Rules for Eval Inside |Initializer|</h1>
-    <p>These static semantics are applied by PerformEval when a direct eval call occurs inside a class field initializer.</p>
-    <emu-grammar>ScriptBody : StatementList</emu-grammar>
-    <ul>
-      <li>It is a Syntax Error if ContainsArguments of |StatementList| is *true*.</li>
-      <li>The remaining eval rules apply as <a href="https://tc39.github.io/ecma262/#sec-performeval-rules-outside-constructors">outside a constructor</a>, <a href="https://tc39.github.io/ecma262/#sec-performeval-rules-outside-methods">inside a method</a>, and <a href="https://tc39.github.io/ecma262/#sec-performeval-rules-outside-functions">inside a function</a>.</li>
-    </ul>
-  </emu-clause>
-</emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -387,8 +375,6 @@ emu-example pre {
       1. Perform ? CreateDataPropertyOrThrow(_receiver_, _fieldName_, _initValue_).
     <emu-alg>
 </emu-clause>
-<emu-note type=editor>TODO: Set the running execution context's PrivateNameEnvironment when calling a function (<a href="https://github.com/anba/proposal-class-fields.git">Issue #40</a>).</emu-note>
-
 
 <emu-clause id="initialize-public-instance-fields">
   <h1>InitializeInstanceFields ( _O_, _constructor_ )</h1>
@@ -795,7 +781,8 @@ emu-example pre {
             1. Let _F_ be FunctionAllocate(_proto_, _strict_, _kind_).
             1. Let _realmF_ be _F_.[[Realm]].
             1. Let _scope_ be _realmF_.[[GlobalEnv]].
-            1. Perform FunctionInitialize(_F_, ~Normal~, _parameters_, _body_, _scope_).
+            1. <ins>Let _privateNameScope_ be a new Lexical Environment.</ins>
+            1. Perform FunctionInitialize(_F_, ~Normal~, _parameters_, _body_, _scope_<ins>, _privateNameScope_</ins>).
             1. If _kind_ is `"generator"`, then
               1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
               1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
@@ -808,15 +795,73 @@ emu-example pre {
             <p>A `prototype` property is created for every non-async function created using CreateDynamicFunction to provide for the possibility that the function will be used as a constructor.</p>
           </emu-note>
         </emu-clause>
-      </emu-clause>
-    </emu-clause>
 
 
     <emu-clause id="sec-eval-x">
       <h1>eval ( _x_ )</h1>
+<emu-clause id="sec-performeval">
+  <h1>Runtime Semantics: PerformEval ( _x_, _evalRealm_, _strictCaller_, _direct_ )</h1>
+        <p>The abstract operation PerformEval with arguments _x_, _evalRealm_, _strictCaller_, and _direct_ performs the following steps:</p>
+        <emu-alg>
+          1. Assert: If _direct_ is *false*, then _strictCaller_ is also *false*.
+          1. If Type(_x_) is not String, return _x_.
+          1. Let _thisEnvRec_ be ! GetThisEnvironment().
+          1. If _thisEnvRec_ is a function Environment Record, then
+            1. Let _F_ be _thisEnvRec_.[[FunctionObject]].
+            1. Let _inFunction_ be *true*.
+            1. Let _inMethod_ be _thisEnvRec_.HasSuperBinding().
+            1. If _F_.[[ConstructorKind]] is `"derived"`, let _inDerivedConstructor_ be *true*; otherwise, let _inDerivedConstructor_ be *false*.
+          1. Else,
+            1. Let _inFunction_ be *false*.
+            1. Let _inMethod_ be *false*.
+            1. Let _inDerivedConstructor_ be *false*.
+          1. Let _script_ be the ECMAScript code that is the result of parsing _x_, interpreted as UTF-16 encoded Unicode text as described in <emu-xref href="#sec-ecmascript-language-types-string-type"></emu-xref>, for the goal symbol |Script|. If _inFunction_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-functions"></emu-xref> are applied. If _inMethod_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-methods"></emu-xref> are applied. If _inDerivedConstructor_ is *false*, additional early error rules from <emu-xref href="#sec-performeval-rules-outside-constructors"></emu-xref> are applied. If the parse fails, throw a *SyntaxError* exception. If any early errors are detected, throw a *SyntaxError* or a *ReferenceError* exception, depending on the type of the error (but see also clause <emu-xref href="#sec-error-handling-and-language-extensions"></emu-xref>). Parsing and early error detection may be interweaved in an implementation-dependent manner.
+          1. If _script_ Contains |ScriptBody| is *false*, return *undefined*.
+          1. Let _body_ be the |ScriptBody| of _script_.
+          1. If _strictCaller_ is *true*, let _strictEval_ be *true*.
+          1. Else, let _strictEval_ be IsStrict of _script_.
+          1. Let _ctx_ be the running execution context.
+          1. NOTE: If _direct_ is *true*, _ctx_ will be the execution context that performed the direct eval. If _direct_ is *false*, _ctx_ will be the execution context for the invocation of the `eval` function.
+          1. If _direct_ is *true*, then
+            1. Let _lexEnv_ be NewDeclarativeEnvironment(_ctx_'s LexicalEnvironment).
+            1. Let _varEnv_ be _ctx_'s VariableEnvironment.
+            1. <ins>Let _privateNameEnv_ be _ctx_'s PrivateNameEnvironment.</ins>
+          1. Else,
+            1. Let _lexEnv_ be NewDeclarativeEnvironment(_evalRealm_.[[GlobalEnv]]).
+            1. Let _varEnv_ be _evalRealm_.[[GlobalEnv]].
+            1. <ins>Let _privateNameEnv_ be a new Lexical Environment.</ins>
+          1. If _strictEval_ is *true*, set _varEnv_ to _lexEnv_.
+          1. If _ctx_ is not already suspended, suspend _ctx_.
+          1. Let _evalCxt_ be a new ECMAScript code execution context.
+          1. Set the _evalCxt_'s Function to *null*.
+          1. Set the _evalCxt_'s Realm to _evalRealm_.
+          1. Set the _evalCxt_'s ScriptOrModule to _ctx_'s ScriptOrModule.
+          1. Set the _evalCxt_'s VariableEnvironment to _varEnv_.
+          1. Set the _evalCxt_'s LexicalEnvironment to _lexEnv_.
+          1. <ins>Set the _evalCxt_'s PrivateNameEnvironment to _privateNameEnv_.</ins>
+          1. Push _evalCxt_ on to the execution context stack; _evalCxt_ is now the running execution context.
+          1. Let _result_ be EvalDeclarationInstantiation(_body_, _varEnv_, _lexEnv_, <ins>_privateNameEnv_</ins>_strictEval_).
+          1. If _result_.[[Type]] is ~normal~, then
+            1. Set _result_ to the result of evaluating _body_.
+          1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
+            1. Set _result_ to NormalCompletion(*undefined*).
+          1. Suspend _evalCxt_ and remove it from the execution context stack.
+          1. Resume the context that is now on the top of the execution context stack as the running execution context.
+          1. Return Completion(_result_).
+        </emu-alg>
+  </emu-clause>
+  <emu-clause id="sec-performeval-rules-in-initializer">
+    <h1>Additional Early Error Rules for Eval Inside |Initializer|</h1>
+    <p>These static semantics are applied by PerformEval when a direct eval call occurs inside a class field initializer.</p>
+    <emu-grammar>ScriptBody : StatementList</emu-grammar>
+    <ul>
+      <li>It is a Syntax Error if ContainsArguments of |StatementList| is *true*.</li>
+      <li>The remaining eval rules apply as <a href="https://tc39.github.io/ecma262/#sec-performeval-rules-outside-constructors">outside a constructor</a>, <a href="https://tc39.github.io/ecma262/#sec-performeval-rules-outside-methods">inside a method</a>, and <a href="https://tc39.github.io/ecma262/#sec-performeval-rules-outside-functions">inside a function</a>.</li>
+    </ul>
+  </emu-clause>
       <emu-clause id="sec-evaldeclarationinstantiation" aoid="EvalDeclarationInstantiation">
-        <h1>Runtime Semantics: EvalDeclarationInstantiation( _body_, _varEnv_, _lexEnv_, _strict_ )</h1>
-        <p>When the abstract operation EvalDeclarationInstantiation is called with arguments _body_, _varEnv_, _lexEnv_, and _strict_, the following steps are taken:</p>
+        <h1>Runtime Semantics: EvalDeclarationInstantiation( _body_, _varEnv_, _lexEnv_, <ins>_privateNameEnv_,</ins>_strict_ )</h1>
+        <p>When the abstract operation EvalDeclarationInstantiation is called with arguments _body_, _varEnv_, _lexEnv_, _privateNameEnv_, and _strict_, the following steps are taken:</p>
         <emu-alg>
           1. Let _varNames_ be the VarDeclaredNames of _body_.
           1. Let _varDeclarations_ be the VarScopedDeclarations of _body_.
@@ -840,7 +885,7 @@ emu-example pre {
                   1. NOTE: A direct eval will not hoist var declaration over a like-named lexical declaration.
               1. Let _thisLex_ be _thisLex_'s outer environment reference.
           1. <ins>Let _privateNames_ be an empty List.</ins>
-          1. <ins>Let _privateEnv_ be the running execution context's PrivateNameEnvironment.</ins>
+          1. <ins>Let _privateEnv_ be _privateNameEnv_.</ins>
           1. <ins>Repeat while _privateEnv_ is not *null*,</ins>
             1. <ins>For each binding named _N_ in _privateEnv_,</ins>
               1. <ins>If _privateNames_ does not contain _N_, append _N_ to _privateNames_.</ins>
@@ -881,7 +926,7 @@ emu-example pre {
                 1. Perform ? _lexEnvRec_.CreateMutableBinding(_dn_, *false*).
           1. For each Parse Node _f_ in _functionsToInitialize_, do
             1. Let _fn_ be the sole element of the BoundNames of _f_.
-            1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument _lexEnv_.
+            1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument<ins>s</ins> _lexEnv_ <ins>and _privateNameEnv_</ins>.
             1. If _varEnvRec_ is a global Environment Record, then
               1. Perform ? _varEnvRec_.CreateGlobalFunctionBinding(_fn_, _fo_, *true*).
             1. Else,
@@ -904,8 +949,473 @@ emu-example pre {
           1. Return NormalCompletion(~empty~).
         </emu-alg>
       </emu-clause>
+</emu-clause>
+
+          <emu-clause id="sec-moduledeclarationenvironmentsetup" aoid="ModuleDeclarationEnvironmentSetup">
+            <h1>ModuleDeclarationEnvironmentSetup( _module_ )</h1>
+
+            <p>The ModuleDeclarationEnvironmentSetup abstract operation is used by InnerModuleInstantiation to initialize the Lexical Environment of the module, including resolving all imported bindings.</p>
+
+            <p>This abstract operation performs the following steps:</p>
+
+            <emu-alg>
+              1. For each ExportEntry Record _e_ in _module_.[[IndirectExportEntries]], do
+                1. Let _resolution_ be ? _module_.ResolveExport(_e_.[[ExportName]], &laquo; &raquo;).
+                1. If _resolution_ is *null* or `"ambiguous"`, throw a *SyntaxError* exception.
+                1. Assert: _resolution_ is a ResolvedBinding Record.
+              1. Assert: All named exports from _module_ are resolvable.
+              1. Let _realm_ be _module_.[[Realm]].
+              1. Assert: _realm_ is not *undefined*.
+              1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
+              1. Set _module_.[[Environment]] to _env_.
+              1. Let _envRec_ be _env_'s EnvironmentRecord.
+              1. For each ImportEntry Record _in_ in _module_.[[ImportEntries]], do
+                1. Let _importedModule_ be ! HostResolveImportedModule(_module_, _in_.[[ModuleRequest]]).
+                1. NOTE: The above call cannot fail because imported module requests are a subset of _module_.[[RequestedModules]], and these have been resolved earlier in this algorithm.
+                1. If _in_.[[ImportName]] is `"*"`, then
+                  1. Let _namespace_ be ? GetModuleNamespace(_importedModule_).
+                  1. Perform ! _envRec_.CreateImmutableBinding(_in_.[[LocalName]], *true*).
+                  1. Call _envRec_.InitializeBinding(_in_.[[LocalName]], _namespace_).
+                1. Else,
+                  1. Let _resolution_ be ? _importedModule_.ResolveExport(_in_.[[ImportName]], &laquo; &raquo;).
+                  1. If _resolution_ is *null* or `"ambiguous"`, throw a *SyntaxError* exception.
+                  1. Call _envRec_.CreateImportBinding(_in_.[[LocalName]], _resolution_.[[Module]], _resolution_.[[BindingName]]).
+              1. Let _code_ be _module_.[[ECMAScriptCode]].
+              1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
+              1. Let _declaredVarNames_ be a new empty List.
+              1. For each element _d_ in _varDeclarations_, do
+                1. For each element _dn_ of the BoundNames of _d_, do
+                  1. If _dn_ is not an element of _declaredVarNames_, then
+                    1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
+                    1. Call _envRec_.InitializeBinding(_dn_, *undefined*).
+                    1. Append _dn_ to _declaredVarNames_.
+              1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
+              1. <ins>Let _privateNameEnv_ be a new Lexical Environment.</ins>
+              1. For each element _d_ in _lexDeclarations_, do
+                1. For each element _dn_ of the BoundNames of _d_, do
+                  1. If IsConstantDeclaration of _d_ is *true*, then
+                    1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
+                  1. Else,
+                    1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
+                  1
+                    1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument<ins>s</ins> _env_ <ins>and _privateNameEnv_</ins>.
+                    1. Call _envRec_.InitializeBinding(_dn_, _fo_).
+            </emu-alg>
+          </emu-clause>
+
+    <!-- es6num="9.2.12" -->
+    <emu-clause id="sec-functiondeclarationinstantiation" aoid="FunctionDeclarationInstantiation">
+      <h1>FunctionDeclarationInstantiation ( _func_, _argumentsList_ )</h1>
+      <emu-note>
+        <p>When an execution context is established for evaluating an ECMAScript function a new function Environment Record is created and bindings for each formal parameter are instantiated in that Environment Record. Each declaration in the function body is also instantiated. If the function's formal parameters do not include any default value initializers then the body declarations are instantiated in the same Environment Record as the parameters. If default value parameter initializers exist, a second Environment Record is created for the body declarations. Formal parameters and functions are initialized as part of FunctionDeclarationInstantiation. All other bindings are initialized during evaluation of the function body.</p>
+      </emu-note>
+      <p>FunctionDeclarationInstantiation is performed as follows using arguments _func_ and _argumentsList_. _func_ is the function object for which the execution context is being established.</p>
+      <!--
+        WARNING: If you add, remove, rename, or repurpose any variable names
+                 within this algorithm, you may need to update
+                 #sec-web-compat-functiondeclarationinstantiation accordingly.
+      -->
+      <emu-alg>
+        1. Let _calleeContext_ be the running execution context.
+        1. Let _env_ be the LexicalEnvironment of _calleeContext_.
+        1. Let _envRec_ be _env_'s EnvironmentRecord.
+        1. Let _code_ be _func_.[[ECMAScriptCode]].
+        1. Let _strict_ be _func_.[[Strict]].
+        1. Let _formals_ be _func_.[[FormalParameters]].
+        1. Let _parameterNames_ be the BoundNames of _formals_.
+        1. If _parameterNames_ has any duplicate entries, let _hasDuplicates_ be *true*. Otherwise, let _hasDuplicates_ be *false*.
+        1. Let _simpleParameterList_ be IsSimpleParameterList of _formals_.
+        1. Let _hasParameterExpressions_ be ContainsExpression of _formals_.
+        1. Let _varNames_ be the VarDeclaredNames of _code_.
+        1. Let _varDeclarations_ be the VarScopedDeclarations of _code_.
+        1. Let _lexicalNames_ be the LexicallyDeclaredNames of _code_.
+        1. Let _functionNames_ be a new empty List.
+        1. Let _functionsToInitialize_ be a new empty List.
+        1. For each _d_ in _varDeclarations_, in reverse list order, do
+          1. If _d_ is neither a |VariableDeclaration| nor a |ForBinding| nor a |BindingIdentifier|, then
+            1. Assert: _d_ is either a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|.
+            1. Let _fn_ be the sole element of the BoundNames of _d_.
+            1. If _fn_ is not an element of _functionNames_, then
+              1. Insert _fn_ as the first element of _functionNames_.
+              1. NOTE: If there are multiple function declarations for the same name, the last declaration is used.
+              1. Insert _d_ as the first element of _functionsToInitialize_.
+        1. Let _argumentsObjectNeeded_ be *true*.
+        1. If _func_.[[ThisMode]] is ~lexical~, then
+          1. NOTE: Arrow functions never have an arguments objects.
+          1. Set _argumentsObjectNeeded_ to *false*.
+        1. Else if `"arguments"` is an element of _parameterNames_, then
+          1. Set _argumentsObjectNeeded_ to *false*.
+        1. Else if _hasParameterExpressions_ is *false*, then
+          1. If `"arguments"` is an element of _functionNames_ or if `"arguments"` is an element of _lexicalNames_, then
+            1. Set _argumentsObjectNeeded_ to *false*.
+        1. For each String _paramName_ in _parameterNames_, do
+          1. Let _alreadyDeclared_ be _envRec_.HasBinding(_paramName_).
+          1. NOTE: Early errors ensure that duplicate parameter names can only occur in non-strict functions that do not have parameter default values or rest parameters.
+          1. If _alreadyDeclared_ is *false*, then
+            1. Perform ! _envRec_.CreateMutableBinding(_paramName_, *false*).
+            1. If _hasDuplicates_ is *true*, then
+              1. Perform ! _envRec_.InitializeBinding(_paramName_, *undefined*).
+        1. If _argumentsObjectNeeded_ is *true*, then
+          1. If _strict_ is *true* or if _simpleParameterList_ is *false*, then
+            1. Let _ao_ be CreateUnmappedArgumentsObject(_argumentsList_).
+          1. Else,
+            1. NOTE: mapped argument object is only provided for non-strict functions that don't have a rest parameter, any parameter default value initializers, or any destructured parameters.
+            1. Let _ao_ be CreateMappedArgumentsObject(_func_, _formals_, _argumentsList_, _envRec_).
+          1. If _strict_ is *true*, then
+            1. Perform ! _envRec_.CreateImmutableBinding(`"arguments"`, *false*).
+          1. Else,
+            1. Perform ! _envRec_.CreateMutableBinding(`"arguments"`, *false*).
+          1. Call _envRec_.InitializeBinding(`"arguments"`, _ao_).
+          1. Let _parameterBindings_ be a new List of _parameterNames_ with `"arguments"` appended.
+        1. Else,
+          1. Let _parameterBindings_ be _parameterNames_.
+        1. Let _iteratorRecord_ be CreateListIteratorRecord(_argumentsList_).
+        1. If _hasDuplicates_ is *true*, then
+          1. Perform ? IteratorBindingInitialization for _formals_ with _iteratorRecord_ and *undefined* as arguments.
+        1. Else,
+          1. Perform ? IteratorBindingInitialization for _formals_ with _iteratorRecord_ and _env_ as arguments.
+        1. If _hasParameterExpressions_ is *false*, then
+          1. NOTE: Only a single lexical environment is needed for the parameters and top-level vars.
+          1. Let _instantiatedVarNames_ be a copy of the List _parameterBindings_.
+          1. For each _n_ in _varNames_, do
+            1. If _n_ is not an element of _instantiatedVarNames_, then
+              1. Append _n_ to _instantiatedVarNames_.
+              1. Perform ! _envRec_.CreateMutableBinding(_n_, *false*).
+              1. Call _envRec_.InitializeBinding(_n_, *undefined*).
+          1. Let _varEnv_ be _env_.
+          1. Let _varEnvRec_ be _envRec_.
+        1. Else,
+          1. NOTE: A separate Environment Record is needed to ensure that closures created by expressions in the formal parameter list do not have visibility of declarations in the function body.
+          1. Let _varEnv_ be NewDeclarativeEnvironment(_env_).
+          1. Let _varEnvRec_ be _varEnv_'s EnvironmentRecord.
+          1. Set the VariableEnvironment of _calleeContext_ to _varEnv_.
+          1. Let _instantiatedVarNames_ be a new empty List.
+          1. For each _n_ in _varNames_, do
+            1. If _n_ is not an element of _instantiatedVarNames_, then
+              1. Append _n_ to _instantiatedVarNames_.
+              1. Perform ! _varEnvRec_.CreateMutableBinding(_n_, *false*).
+              1. If _n_ is not an element of _parameterBindings_ or if _n_ is an element of _functionNames_, let _initialValue_ be *undefined*.
+              1. Else,
+                1. Let _initialValue_ be ! _envRec_.GetBindingValue(_n_, *false*).
+              1. Call _varEnvRec_.InitializeBinding(_n_, _initialValue_).
+              1. NOTE: vars whose names are the same as a formal parameter, initially have the same value as the corresponding initialized parameter.
+        1. NOTE: Annex <emu-xref href="#sec-web-compat-functiondeclarationinstantiation"></emu-xref> adds additional steps at this point.
+        1. If _strict_ is *false*, then
+          1. Let _lexEnv_ be NewDeclarativeEnvironment(_varEnv_).
+          1. NOTE: Non-strict functions use a separate lexical Environment Record for top-level lexical declarations so that a direct eval can determine whether any var scoped declarations introduced by the eval code conflict with pre-existing top-level lexically scoped declarations. This is not needed for strict functions because a strict direct eval always places all declarations into a new Environment Record.
+        1. Else, let _lexEnv_ be _varEnv_.
+        1. Let _lexEnvRec_ be _lexEnv_'s EnvironmentRecord.
+        1. Set the LexicalEnvironment of _calleeContext_ to _lexEnv_.
+        1. Let _lexDeclarations_ be the LexicallyScopedDeclarations of _code_.
+        1. For each element _d_ in _lexDeclarations_, do
+          1. NOTE: A lexically declared name cannot be the same as a function/generator declaration, formal parameter, or a var name. Lexically declared names are only instantiated here but not initialized.
+          1. For each element _dn_ of the BoundNames of _d_, do
+            1. If IsConstantDeclaration of _d_ is *true*, then
+              1. Perform ! _lexEnvRec_.CreateImmutableBinding(_dn_, *true*).
+            1. Else,
+              1. Perform ! _lexEnvRec_.CreateMutableBinding(_dn_, *false*).
+        1. <ins>Let _privateNameEnv_ be the PrivateNameEnvironment of _calleeContext_.</ins>
+        1. For each Parse Node _f_ in _functionsToInitialize_, do
+          1. Let _fn_ be the sole element of the BoundNames of _f_.
+          1. Let _fo_ be the result of performing InstantiateFunctionObject for _f_ with argument<ins>s</ins> _lexEnv_ <ins>and _privateNameEnv_</ins>.
+          1. Perform ! _varEnvRec_.SetMutableBinding(_fn_, _fo_, *false*).
+        1. Return NormalCompletion(~empty~).
+      </emu-alg>
+      <emu-note>
+        <p><emu-xref href="#sec-block-level-function-declarations-web-legacy-compatibility-semantics"></emu-xref> provides an extension to the above algorithm that is necessary for backwards compatibility with web browser implementations of ECMAScript that predate ECMAScript 2015.</p>
+      </emu-note>
+      <emu-note>
+        <p>Parameter |Initializer|s may contain direct eval expressions. Any top level declarations of such evals are only visible to the eval code (<emu-xref href="#sec-types-of-source-code"></emu-xref>). The creation of the environment for such declarations is described in <emu-xref href="#sec-function-definitions-runtime-semantics-iteratorbindinginitialization"></emu-xref>.</p>
+      </emu-note>
     </emu-clause>
 
+    <!-- es6num="13.2.14" -->
+    <emu-clause id="sec-blockdeclarationinstantiation" aoid="BlockDeclarationInstantiation">
+      <h1>Runtime Semantics: BlockDeclarationInstantiation( _code_, _env_ )</h1>
+      <emu-note>
+        <p>When a |Block| or |CaseBlock| is evaluated a new declarative Environment Record is created and bindings for each block scoped variable, constant, function, or class declared in the block are instantiated in the Environment Record.</p>
+      </emu-note>
+      <p>BlockDeclarationInstantiation is performed as follows using arguments _code_ and _env_. _code_ is the Parse Node corresponding to the body of the block. _env_ is the Lexical Environment in which bindings are to be created.</p>
+      <!--
+        WARNING: If you add, remove, rename, or repurpose any variable names
+                 within this algorithm, you may need to update
+                 #sec-web-compat-blockdeclarationinstantiation accordingly.
+      -->
+      <emu-alg>
+        1. Let _envRec_ be _env_'s EnvironmentRecord.
+        1. Assert: _envRec_ is a declarative Environment Record.
+        1. Let _declarations_ be the LexicallyScopedDeclarations of _code_.
+        1. <ins>Let _privateNameEnv_ be the running execution context's PrivateNameEnvironment.</ins>
+        1. For each element _d_ in _declarations_, do
+          1. For each element _dn_ of the BoundNames of _d_, do
+            1. If IsConstantDeclaration of _d_ is *true*, then
+              1. Perform ! _envRec_.CreateImmutableBinding(_dn_, *true*).
+            1. Else,
+              1. Perform ! _envRec_.CreateMutableBinding(_dn_, *false*).
+          1. If _d_ is a |FunctionDeclaration|, a |GeneratorDeclaration|, an |AsyncFunctionDeclaration|, or an |AsyncGeneratorDeclaration|, then
+            1. Let _fn_ be the sole element of the BoundNames of _d_.
+            1. Let _fo_ be the result of performing InstantiateFunctionObject for _d_ with argument<ins>s</ins> _env_ <ins>and _privateNameEnv_</ins>.
+            1. Perform _envRec_.InitializeBinding(_fn_, _fo_).
+      </emu-alg>
+    </emu-clause>
+
+    <!-- es6num="14.2.16" -->
+    <emu-clause id="sec-arrow-function-definitions-runtime-semantics-evaluation">
+      <h1>Runtime Semantics: Evaluation</h1>
+      <emu-grammar>ArrowFunction : ArrowParameters `=&gt;` ConciseBody</emu-grammar>
+      <emu-alg>
+        1. If the function code for this |ArrowFunction| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _parameters_ be CoveredFormalsList of |ArrowParameters|.
+        1. Let _closure_ be FunctionCreate(~Arrow~, _parameters_, |ConciseBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-grammar>GeneratorExpression : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. If the function code for this |GeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _closure_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
+        1. Perform DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-grammar>GeneratorExpression : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. If the function code for this |GeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _funcEnv_ be NewDeclarativeEnvironment(_scope_).
+        1. Let _envRec_ be _funcEnv_'s EnvironmentRecord.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Perform _envRec_.CreateImmutableBinding(_name_, *false*).
+        1. Let _closure_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _funcEnv_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
+        1. Perform DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform SetFunctionName(_closure_, _name_).
+        1. Perform _envRec_.InitializeBinding(_name_, _closure_).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncGeneratorExpression : `async` [no LineTerminator here] `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for this |AsyncGeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _scope_, _strict_).
+        1. Let _prototype_ be ! ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Return _closure_.
+      </emu-alg>
+
+      <emu-grammar>
+        AsyncGeneratorExpression : `async` [no LineTerminator here] `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for this |AsyncGeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_scope_).
+        1. Let _envRec_ be _funcEnv_'s EnvironmentRecord.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Perform ! _envRec_.CreateImmutableBinding(_name_).
+        1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _funcEnv_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Let _prototype_ be ! ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform ! SetFunctionName(_closure_, _name_).
+        1. Perform ! _envRec_.InitializeBinding(_name_, _closure_).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncGeneratorExpression : `async` [no LineTerminator here] `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for this |AsyncGeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Let _prototype_ be ! ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Return _closure_.
+      </emu-alg>
+
+      <emu-grammar>
+        AsyncGeneratorExpression : `async` [no LineTerminator here] `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for this |AsyncGeneratorExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_scope_).
+        1. Let _envRec_ be _funcEnv_'s EnvironmentRecord.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Perform ! _envRec_.CreateImmutableBinding(_name_).
+        1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _funcEnv_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Let _prototype_ be ! ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform ! SetFunctionName(_closure_, _name_).
+        1. Perform ! _envRec_.InitializeBinding(_name_, _closure_).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncFunctionExpression : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for |AsyncFunctionExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _closure_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Return _closure_.
+      </emu-alg>
+
+      <emu-grammar>
+        AsyncFunctionExpression : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for |AsyncFunctionExpression| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _funcEnv_ be ! NewDeclarativeEnvironment(_scope_).
+        1. Let _envRec_ be _funcEnv_'s EnvironmentRecord.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Perform ! _envRec_.CreateImmutableBinding(_name_).
+        1. Let _closure_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _funcEnv_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Perform ! SetFunctionName(_closure_, _name_).
+        1. Perform ! _envRec_.InitializeBinding(_name_, _closure_).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncArrowFunction : `async` [no LineTerminator here] AsyncArrowBindingIdentifier [no LineTerminator here] `=>` AsyncConciseBody
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for this |AsyncArrowFunction| is strict mode code, let _strict_ be *true*. Otherwise, let _strict_ be *false*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _parameters_ be |AsyncArrowBindingIdentifier|.
+        1. Let _closure_ be ! AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Return _closure_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead [no LineTerminator here] `=>` AsyncConciseBody
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for this |AsyncArrowFunction| is strict mode code, let _strict_ be *true*. Otherwise, let _strict_ be *false*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
+        1. Let _parameters_ be the |ArrowFormalParameters| of _head_.
+        1. Let _closure_ be ! AsyncFunctionCreate(~Arrow~, _parameters_, |AsyncConciseBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Return _closure_.
+      </emu-alg>
+    </emu-clause>
+
+
+    <!-- es6num="14.3.8" -->
+    <emu-clause id="sec-runtime-semantics-definemethod">
+      <h1>Runtime Semantics: DefineMethod</h1>
+      <p>With parameters _object_ and optional parameter _functionPrototype_.</p>
+      <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. If the function code for this |MethodDefinition| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. If _functionPrototype_ is present as a parameter, then
+          1. Let _kind_ be ~Normal~.
+          1. Let _prototype_ be _functionPrototype_.
+        1. Else,
+          1. Let _kind_ be ~Method~.
+          1. Let _prototype_ be the intrinsic object %FunctionPrototype%.
+        1. Let _closure_ be FunctionCreate(_kind_, |UniqueFormalParameters|, |FunctionBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_, _prototype_).
+        1. Perform MakeMethod(_closure_, _object_).
+        1. Return the Record{[[Key]]: _propKey_, [[Closure]]: _closure_}.
+      </emu-alg>
+    </emu-clause>
+
+
+    <!-- es6num="14.3.9" -->
+    <emu-clause id="sec-method-definitions-runtime-semantics-propertydefinitionevaluation">
+      <h1>Runtime Semantics: PropertyDefinitionEvaluation</h1>
+      <p>With parameters _object_ and _enumerable_.</p>
+      <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
+      <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. If the function code for this |MethodDefinition| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
+        1. Let _closure_ be FunctionCreate(~Method~, _formalParameterList_, |FunctionBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Perform MakeMethod(_closure_, _object_).
+        1. Perform SetFunctionName(_closure_, _propKey_, `"get"`).
+        1. Let _desc_ be the PropertyDescriptor{[[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+      </emu-alg>
+      <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. If the function code for this |MethodDefinition| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _closure_ be FunctionCreate(~Method~, |PropertySetParameterList|, |FunctionBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Perform MakeMethod(_closure_, _object_).
+        1. Perform SetFunctionName(_closure_, _propKey_, `"set"`).
+        1. Let _desc_ be the PropertyDescriptor{[[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+      </emu-alg>
+      <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. If the function code for this |GeneratorMethod| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _closure_ be GeneratorFunctionCreate(~Method~, |UniqueFormalParameters|, |GeneratorBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Perform MakeMethod(_closure_, _object_).
+        1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
+        1. Perform DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform SetFunctionName(_closure_, _propKey_).
+        1. Let _desc_ be the PropertyDescriptor{[[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+      </emu-alg>
+      <emu-grammar>
+        AsyncGeneratorMethod : `async` [no LineTerminator here] `*` PropertyName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. If the function code for this |AsyncGeneratorMethod| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the running execution context's LexicalEnvironment.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _closure_ be ! AsyncGeneratorFunctionCreate(~Method~, |UniqueFormalParameters|, |AsyncGeneratorBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Perform ! MakeMethod(_closure_, _object_).
+        1. Let _prototype_ be ! ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform ! DefinePropertyOrThrow(_closure_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform ! SetFunctionName(_closure_, _propKey_).
+        1. Let _desc_ be PropertyDescriptor{[[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+      </emu-alg>
+      <emu-grammar>
+        AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. Let _propKey_ be the result of evaluating |PropertyName|.
+        1. ReturnIfAbrupt(_propKey_).
+        1. If the function code for this |AsyncMethod| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. <ins>Let _privateNameScope_ be the PrivateNameEnvironment of the running execution context.</ins>
+        1. Let _closure_ be ! AsyncFunctionCreate(~Method~, |UniqueFormalParameters|, |AsyncFunctionBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Perform ! MakeMethod(_closure_, _object_).
+        1. Perform ! SetFunctionName(_closure_, _propKey_).
+        1. Let _desc_ be the PropertyDescriptor{[[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
+        1. Return ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
+      </emu-alg>
+    </emu-clause>
 </emu-clause>
 
 <emu-clause id="sec-private-names">
@@ -1132,6 +1642,10 @@ emu-example pre {
   </emu-clause>
 </emu-clause>
 
+  <emu-clause id="sec-lexically-scoped-private-names">
+    <h1>Lexically scoped Private Names</h1>
+    <p>Private Names follow typical lexical scoping logic. This section contains amended algorithms for managing the scope of Private Names.</p>
+
 <emu-clause id="sec-execution-contexts">
   <h1>Execution Contexts</h1>
     <emu-table id="table-23" caption="Additional State Components for ECMAScript Code Execution Contexts">
@@ -1174,10 +1688,382 @@ emu-example pre {
     </emu-table>
   <emu-note>The PrivateNameEnvironment Lexical Context is always a chain of Declaration Contexts. Each name begins with `"#"`.</emu-note>
 
-  <emu-note type=editor>Private names could be specified by lumping it all into the LexicalEnvironment. However, this would create false conflicts with object environment records that would need to be resolved. Further, it seems logically cleaner to separate out the distinct namespace into a distinct object.</emu-note>
+  <emu-note type=editor>Private names could have been specified by lumping it all into the LexicalEnvironment. However, this would create false conflicts with object environment records that would need to be resolved. Further, it seems logically cleaner to separate out the distinct namespace into a distinct object.</emu-note>
+  </emu-clause>
 
-  When a new execution context is created for an ECMAScript code execution context, the PrivateNameIdentifiers value is inherited from the running execution context, or if none exists, a new Declaration Context with a *null* parent.
-  <emu-note type=editor>TODO: Elaborate the preceding paragraph with spec text inserted in each relevant place</emu-note>
+  <!-- es6num="9.2" -->
+  <emu-clause id="sec-ecmascript-function-objects">
+    <h1>ECMAScript Function Objects</h1>
+    <p>ECMAScript function objects have the additional internal slots listed in <emu-xref href="#table-27"></emu-xref>.</p>
+    <emu-table id="table-27" caption="Internal Slots of ECMAScript Function Objects">
+      <table>
+        <tbody>
+        <tr>
+          <th>
+            Internal Slot
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+        <tr>
+          <td>
+            [[Environment]]
+          </td>
+          <td>
+            Lexical Environment
+          </td>
+          <td>
+            The Lexical Environment that the function was closed over. Used as the outer environment when evaluating the code of the function.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <ins>[[PrivateNameEnvironment]]</ins>
+          </td>
+          <td>
+            <ins>Lexical Environment</ins>
+          </td>
+          <td>
+            <ins>The Lexical Environment for Private Names that the function was closed over. Used as the outer environment for Private Names when evaluating the code of the function.</ins>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[FormalParameters]]
+          </td>
+          <td>
+            Parse Node
+          </td>
+          <td>
+            The root parse node of the source text that defines the function's formal parameter list.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[FunctionKind]]
+          </td>
+          <td>
+            String
+          </td>
+          <td>
+            Either `"normal"`, `"classConstructor"`, `"generator"`, or `"async"`.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[ECMAScriptCode]]
+          </td>
+          <td>
+            Parse Node
+          </td>
+          <td>
+            The root parse node of the source text that defines the function's body.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[ConstructorKind]]
+          </td>
+          <td>
+            String
+          </td>
+          <td>
+            Either `"base"` or `"derived"`.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[Realm]]
+          </td>
+          <td>
+            Realm Record
+          </td>
+          <td>
+            The realm in which the function was created and which provides any intrinsic objects that are accessed when evaluating the function.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[ScriptOrModule]]
+          </td>
+          <td>
+            Script Record or Module Record
+          </td>
+          <td>
+            The script or module in which the function was created.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[ThisMode]]
+          </td>
+          <td>
+            (lexical, strict, global)
+          </td>
+          <td>
+            Defines how `this` references are interpreted within the formal parameters and code body of the function. ~lexical~ means that `this` refers to the *this* value of a lexically enclosing function. ~strict~ means that the *this* value is used exactly as provided by an invocation of the function. ~global~ means that a *this* value of *undefined* is interpreted as a reference to the global object.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[Strict]]
+          </td>
+          <td>
+            Boolean
+          </td>
+          <td>
+            *true* if this is a strict function, *false* if this is a non-strict function.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[HomeObject]]
+          </td>
+          <td>
+            Object
+          </td>
+          <td>
+            If the function uses `super`, this is the object whose [[GetPrototypeOf]] provides the object where `super` property lookups begin.
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+
+    <!-- es6num="9.2.4" -->
+    <emu-clause id="sec-functioninitialize" aoid="FunctionInitialize">
+      <h1>FunctionInitialize ( _F_, _kind_, _ParameterList_, _Body_, _Scope_<ins>, _PrivateNameScope_</ins> )</h1>
+      <p>The abstract operation FunctionInitialize requires the arguments: a function object _F_, _kind_ which is one of (Normal, Method, Arrow), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_<ins>, and a Lexical environment _PrivateNameScope_</ins>. FunctionInitialize performs the following steps:</p>
+      <emu-alg>
+        1. Let _len_ be the ExpectedArgumentCount of _ParameterList_.
+        1. Perform ! SetFunctionLength(_F_, _len_).
+        1. Let _Strict_ be _F_.[[Strict]].
+        1. Set _F_.[[Environment]] to _Scope_.
+        1. <ins>Set _F_.[[PrivateNameEnvironment]] to _PrivateNameScope_.</ins>
+        1. Set _F_.[[FormalParameters]] to _ParameterList_.
+        1. Set _F_.[[ECMAScriptCode]] to _Body_.
+        1. Set _F_.[[ScriptOrModule]] to GetActiveScriptOrModule().
+        1. If _kind_ is ~Arrow~, set _F_.[[ThisMode]] to ~lexical~.
+        1. Else if _Strict_ is *true*, set _F_.[[ThisMode]] to ~strict~.
+        1. Else, set _F_.[[ThisMode]] to ~global~.
+        1. Return _F_.
+      </emu-alg>
+    </emu-clause>
+
+    <!-- es6num="9.2.5" -->
+    <emu-clause id="sec-functioncreate" aoid="FunctionCreate">
+      <h1>FunctionCreate ( _kind_, _ParameterList_, _Body_, _Scope_, <ins>_PrivateNameScope_,</ins> _Strict_ [ , _prototype_ ] )</h1>
+      <p>The abstract operation FunctionCreate requires the arguments: _kind_ which is one of (Normal, Method, Arrow), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_, <ins>a Lexical Environment specified by _PrivateNameScope_,</ins> a Boolean flag _Strict_, and optionally, an object _prototype_. FunctionCreate performs the following steps:</p>
+      <emu-alg>
+        1. If _prototype_ is not present, then
+          1. Set _prototype_ to the intrinsic object %FunctionPrototype%.
+        1. If _kind_ is not ~Normal~, let _allocKind_ be `"non-constructor"`.
+        1. Else, let _allocKind_ be `"normal"`.
+        1. Let _F_ be FunctionAllocate(_prototype_, _Strict_, _allocKind_).
+        1. Return FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_<ins>, _PrivateNameScope_</ins>).
+      </emu-alg>
+    </emu-clause>
+
+    <!-- es6num="9.2.6" -->
+    <emu-clause id="sec-generatorfunctioncreate" aoid="GeneratorFunctionCreate">
+      <h1>GeneratorFunctionCreate ( _kind_, _ParameterList_, _Body_, _Scope_, <ins>_PrivateNameScope_,</ins> _Strict_ )</h1>
+      <p>The abstract operation GeneratorFunctionCreate requires the arguments: _kind_ which is one of (Normal, Method), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_, <ins>a Lexical Environment specified by _PrivateNameScope_,</ins> and a Boolean flag _Strict_. GeneratorFunctionCreate performs the following steps:</p>
+      <emu-alg>
+        1. Let _functionPrototype_ be the intrinsic object %Generator%.
+        1. Let _F_ be FunctionAllocate(_functionPrototype_, _Strict_, `"generator"`).
+        1. Return FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_<ins>, _PrivateNameScope_</ins>).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgeneratorfunctioncreate" aoid="AsyncGeneratorFunctionCreate">
+      <h1>AsyncGeneratorFunctionCreate (_kind_, _ParameterList_, _Body_, _Scope_, <ins>_PrivateNameScope_,</ins> _Strict_)</h1>
+      <p>The abstract operation AsyncGeneratorFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~), a parameter list Parse Node specified by _ParameterList_, a body Parse Node specified by _Body_, a Lexical Environment specified by _Scope_, <ins>a Lexical Environment specified by _PrivateNameScope_,</ins> and a Boolean flag _Strict_. AsyncGeneratorFunctionCreate performs the following steps:</p>
+      <emu-alg>
+        1. Let _functionPrototype_ be the intrinsic object %AsyncGenerator%.
+        1. Let _F_ be ! FunctionAllocate(_functionPrototype_, _Strict_, `"generator"`).
+        1. Return ! FunctionInitialize(_F_, _kind_, _ParameterList_, _Body_, _Scope_<ins>, _PrivateNameScope_</ins>).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-async-functions-abstract-operations-async-function-create" aoid="AsyncFunctionCreate">
+      <h1>AsyncFunctionCreate ( _kind_, _parameters_, _body_, _Scope_, <ins>_PrivateNameScope_,</ins> _Strict_ )</h1>
+      <p>The abstract operation AsyncFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~, ~Arrow~), a parameter list Parse Node specified by _parameters_, a body Parse Node specified by _body_, a Lexical Environment specified by _Scope_, <ins>a Lexical Environment specified by _PrivateNameScope_,</ins> and a Boolean flag _Strict_. AsyncFunctionCreate performs the following steps:</p>
+      <emu-alg>
+        1. Let _functionPrototype_ be the intrinsic object %AsyncFunctionPrototype%.
+        2. Let _F_ be ! FunctionAllocate(_functionPrototype_, _Strict_, `"async"`).
+        3. Return ! FunctionInitialize(_F_, _kind_, _parameters_, _body_, _Scope_<ins>, _PrivateNameScope_</ins>).
+      </emu-alg>
+    </emu-clause>
+
+
+    <!-- es6num="15.1.7" -->
+    <emu-clause id="sec-runtime-semantics-scriptevaluation" aoid="ScriptEvaluation">
+      <h1>ScriptEvaluation ( _scriptRecord_ )</h1>
+
+      <emu-alg>
+        1. Let _globalEnv_ be _scriptRecord_.[[Realm]].[[GlobalEnv]].
+        1. Let _scriptCxt_ be a new ECMAScript code execution context.
+        1. Set the Function of _scriptCxt_ to *null*.
+        1. Set the Realm of _scriptCxt_ to _scriptRecord_.[[Realm]].
+        1. Set the ScriptOrModule of _scriptCxt_ to _scriptRecord_.
+        1. Set the VariableEnvironment of _scriptCxt_ to _globalEnv_.
+        1. Set the LexicalEnvironment of _scriptCxt_ to _globalEnv_.
+        1. <ins>Let _privateNameEnv_ be a new Lexical Environment.</ins>
+        1. <ins>Set the PrivateNameEnvironment of _scriptCxt_ to _privateNameEnv_.</ins>
+        1. Suspend the currently running execution context.
+        1. Push _scriptCxt_ on to the execution context stack; _scriptCxt_ is now the running execution context.
+        1. Let _scriptBody_ be _scriptRecord_.[[ECMAScriptCode]].
+        1. Let _result_ be GlobalDeclarationInstantiation(_scriptBody_, _globalEnv_).
+        1. If _result_.[[Type]] is ~normal~, then
+          1. Set _result_ to the result of evaluating _scriptBody_.
+        1. If _result_.[[Type]] is ~normal~ and _result_.[[Value]] is ~empty~, then
+          1. Set _result_ to NormalCompletion(*undefined*).
+        1. Suspend _scriptCxt_ and remove it from the execution context stack.
+        1. Assert: The execution context stack is not empty.
+        1. Resume the context that is now on the top of the execution context stack as the running execution context.
+        1. Return Completion(_result_).
+      </emu-alg>
+    </emu-clause>
+
+      <!-- es6num="9.2.1.1" -->
+      <emu-clause id="sec-prepareforordinarycall" aoid="PrepareForOrdinaryCall">
+        <h1>PrepareForOrdinaryCall ( _F_, _newTarget_ )</h1>
+        <p>When the abstract operation PrepareForOrdinaryCall is called with function object _F_ and ECMAScript language value _newTarget_, the following steps are taken:</p>
+        <emu-alg>
+          1. Assert: Type(_newTarget_) is Undefined or Object.
+          1. Let _callerContext_ be the running execution context.
+          1. Let _calleeContext_ be a new ECMAScript code execution context.
+          1. Set the Function of _calleeContext_ to _F_.
+          1. Let _calleeRealm_ be _F_.[[Realm]].
+          1. Set the Realm of _calleeContext_ to _calleeRealm_.
+          1. Set the ScriptOrModule of _calleeContext_ to _F_.[[ScriptOrModule]].
+          1. Let _localEnv_ be NewFunctionEnvironment(_F_, _newTarget_).
+          1. Set the LexicalEnvironment of _calleeContext_ to _localEnv_.
+          1. Set the VariableEnvironment of _calleeContext_ to _localEnv_.
+          1. <ins>Set the PrivateNameEnvironment of _calleeContext_ to  _F_.[[PrivateNameEnvironment]].</ins>
+          1. If _callerContext_ is not already suspended, suspend _callerContext_.
+          1. Push _calleeContext_ onto the execution context stack; _calleeContext_ is now the running execution context.
+          1. NOTE: Any exception objects produced after this point are associated with _calleeRealm_.
+          1. Return _calleeContext_.
+        </emu-alg>
+      </emu-clause>
+
+    <!-- es6num="14.1.19" -->
+    <emu-clause id="sec-function-definitions-runtime-semantics-instantiatefunctionobject">
+      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
+      <p>With parameter<ins>s</ins> _scope_ <ins>and _privateNameScope</ins>.</p>
+      <emu-see-also-para op="InstantiateFunctionObject"></emu-see-also-para>
+      <emu-grammar>FunctionDeclaration : `function` BindingIdentifier `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. If the function code for |FunctionDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Let _F_ be FunctionCreate(~Normal~, |FormalParameters|, |FunctionBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Perform MakeConstructor(_F_).
+        1. Perform SetFunctionName(_F_, _name_).
+        1. Return _F_.
+      </emu-alg>
+      <emu-grammar>FunctionDeclaration : `function` `(` FormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+      <emu-alg>
+        1. Let _F_ be FunctionCreate(~Normal~, |FormalParameters|, |FunctionBody|, _scope_, <ins>_privateNameScope_,</ins> *true*).
+        1. Perform MakeConstructor(_F_).
+        1. Perform SetFunctionName(_F_, `"default"`).
+        1. Return _F_.
+      </emu-alg>
+      <emu-note>
+        <p>An anonymous |FunctionDeclaration| can only occur as part of an `export default` declaration, and its function code is therefore always strict mode code.</p>
+      </emu-note>
+    </emu-clause>
+
+    <!-- es6num="14.4.12" -->
+    <emu-clause id="sec-generator-function-definitions-runtime-semantics-instantiatefunctionobject">
+      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
+      <p>With parameter<ins>s</ins> _scope_ <ins>and _privateNameScope</ins>.</p>
+      <emu-see-also-para op="InstantiateFunctionObject"></emu-see-also-para>
+      <emu-grammar>GeneratorDeclaration : `function` `*` BindingIdentifier `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. If the function code for |GeneratorDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Let _F_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
+        1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform SetFunctionName(_F_, _name_).
+        1. Return _F_.
+      </emu-alg>
+      <emu-grammar>GeneratorDeclaration : `function` `*` `(` FormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+      <emu-alg>
+        1. Let _F_ be GeneratorFunctionCreate(~Normal~, |FormalParameters|, |GeneratorBody|, _scope_,<ins>_privateNameScope_,</ins>  *true*).
+        1. Let _prototype_ be ObjectCreate(%GeneratorPrototype%).
+        1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform SetFunctionName(_F_, `"default"`).
+        1. Return _F_.
+      </emu-alg>
+      <emu-note>
+        <p>An anonymous |GeneratorDeclaration| can only occur as part of an `export default` declaration, and its function code is therefore always strict mode code.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-asyncgenerator-definitions-instantiatefunctionobject">
+      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
+      <p>With parameter<ins>s</ins> _scope_ <ins>and _privateNameScope</ins>.</p>
+      <emu-grammar>
+        AsyncGeneratorDeclaration : `async` [no LineTerminator here] `function` `*` BindingIdentifier `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for |AsyncGeneratorDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Let _F_ be ! AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Let _prototype_ be ! ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform ! DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform ! SetFunctionName(_F_, _name_).
+        1. Return _F_.
+      </emu-alg>
+
+      <emu-grammar>
+        AsyncGeneratorDeclaration : `async` [no LineTerminator here] `function` `*` `(` FormalParameters `)` `{` AsyncGeneratorBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for |AsyncGeneratorDeclaration| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
+        1. Let _F_ be AsyncGeneratorFunctionCreate(~Normal~, |FormalParameters|, |AsyncGeneratorBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Let _prototype_ be ObjectCreate(%AsyncGeneratorPrototype%).
+        1. Perform DefinePropertyOrThrow(_F_, `"prototype"`, PropertyDescriptor{[[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false*}).
+        1. Perform SetFunctionName(_F_, `"default"`).
+        1. Return _F_.
+      </emu-alg>
+      <emu-note>
+        <p>An anonymous |AsyncGeneratorDeclaration| can only occur as part of an `export default` declaration.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-async-function-definitions-InstantiateFunctionObject">
+      <h1>Runtime Semantics: InstantiateFunctionObject</h1>
+      <p>With parameter<ins>s</ins> _scope_ <ins>and _privateNameScope</ins>.</p>
+      <emu-grammar>
+        AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for |AsyncFunctionDeclaration| is strict mode code, let _strict_ be *true*. Otherwise, let _strict_ be *false*.
+        1. Let _name_ be StringValue of |BindingIdentifier|.
+        1. Let _F_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Perform ! SetFunctionName(_F_, _name_).
+        1. Return _F_.
+      </emu-alg>
+      <emu-grammar>
+        AsyncFunctionDeclaration : `async` [no LineTerminator here] `function` `(` FormalParameters `)` `{` AsyncFunctionBody `}`
+      </emu-grammar>
+      <emu-alg>
+        1. If the function code for |AsyncFunctionDeclaration| is strict mode code, let _strict_ be *true*. Otherwise, let _strict_ be *false*.
+        1. Let _F_ be ! AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, <ins>_privateNameScope_,</ins> _strict_).
+        1. Perform ! SetFunctionName(_F_, `"default"`).
+        1. Return _F_.
+      </emu-alg>
+    </emu-clause>
+
+
 </emu-clause>
 
 </emu-clause>


### PR DESCRIPTION
This patch formalizes how the lexical scoping of private names works.
- Direct eval can see outer private names
- Inner functions can see outer private names
- Indirect eval, new scripts, new modules, and function constructors
  start with a blank slate for private names

Closes #40