### PR TITLE
add semicolon to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ class Counter extends HTMLElement {
 window.customElements.define('num-counter', Counter);
 ```
 
-In the above example, you can see a field declared with the syntax `x = 0`. You can also declare a field without an initializer as `x`. By declaring fields up-front, class definitions become more self-documenting; instances go through fewer state transitions, as declared fields are always present.
+In the above example, you can see a field declared with the syntax `x = 0;`. You can also declare a field without an initializer as `x;`. By declaring fields up-front, class definitions become more self-documenting; instances go through fewer state transitions, as declared fields are always present.
 
 ## Private fields
 


### PR DESCRIPTION
As far as I can tell after researching this all morning, semicolons are going to required after properties (yuck) so the example should make it more clear. I know it's nit picky but it makes it clear to me that it is non-standard with almost all other JS and should be explicitly, bluntly, and repeatedly pointed out