### PR TITLE
Added missing `extends` clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For example, in the following example, `new D` would result in an object whose `
 class C {
   y = 1;
 }
-class D {
+class D extends C {
   y;
 }
 ```


### PR DESCRIPTION
Given the context, I looks like the intention was to have D extend C (otherwise there is no reason why `y` would be `1`)