### PR TITLE
Update PRIVATE_SYNTAX_FAQ.md

### DIFF
--- a/PRIVATE_SYNTAX_FAQ.md
+++ b/PRIVATE_SYNTAX_FAQ.md
@@ -310,8 +310,8 @@ class Trick extends Super {
 let target = { };
 let proxy = new Proxy(target, { });
 new Trick(proxy);
-Trick.prototype.checkX(proxy);   // No exception thrown
-Trick.prototype.checkX(target);  // TypeError
+Trick.prototype.checkX.call(proxy);   // No exception thrown
+Trick.prototype.checkX.call(target);  // TypeError
 ```
 
 One way to handle the lack of forwarding to Proxy targets is to use a membrane pattern, e.g., as in [Salesforce's Observable Membrane](https://github.com/salesforce/observable-membrane).


### PR DESCRIPTION
Correct the example to properly use the JavaScript `.call` method. More information about `.call` here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call