### PR TITLE
Reorder strict=true and privateScope to follow FunctionCreate signature

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -319,7 +319,7 @@ emu-example pre {
       1. Let _lex_ be the Lexical Environment of the running execution context.
       1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
       1. Let _privateScope_ be the PrivateEnvironment of the running execution context.
-      1. Let _initializer_ be FunctionCreate(~Method~, _formalParameterList_, |Initializer|, _lex_, *true*, _privateScope_).
+      1. Let _initializer_ be FunctionCreate(~Method~, _formalParameterList_, |Initializer|, _lex_, _privateScope_, *true*).
       1. Perform MakeMethod(_initializer_, _homeObject_).
       1. Let _isAnonymousFunctionDefinition_ be IsAnonymousFunctionDefinition(|Initializer|).
     1. Else,


### PR DESCRIPTION
Seems that the 2 are flipped in order. According to the spec:

> 3.9.4 FunctionCreate ( kind, ParameterList, Body, Scope, PrivateScope, Strict [ , prototype ] )