### PR TITLE
Update Firefox status

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ You can experiment with the class fields proposal using the following complete i
 - Public fields are [enabled by default](https://www.chromestatus.com/feature/6001727933251584) in Chrome 72 / V8 7.2
 - Private fields are [enabled by default](https://www.chromestatus.com/feature/6035156464828416) in Chrome 74 / V8 7.4
 - Public instance fields are [enabled by default](https://bugzilla.mozilla.org/show_bug.cgi?id=1499448) in Firefox 69
-- Public static fields are [enabled](https://bugzilla.mozilla.org/show_bug.cgi?id=1535804) in Firefox 75
+- Public static fields are [enabled](https://bugzilla.mozilla.org/show_bug.cgi?id=1535804) in Firefox Nightly 75 as of Febraury 22, 2020
 - [Moddable XS](https://blog.moddable.com/blog/secureprivate/)
 - [QuickJS](https://www.freelists.org/post/quickjs-devel/New-release,82)
 - [TypeScript 3.8](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#ecmascript-private-fields)
@@ -226,7 +226,7 @@ You can experiment with the class fields proposal using the following complete i
 Further implementations are on the way:
 
 - [Out for review](https://bugs.webkit.org/show_bug.cgi?id=174212) in Safari/JSC
-- [Private instance fields](https://bugzilla.mozilla.org/show_bug.cgi?id=1562054) and [private instance methods and accessors](https://bugzilla.mozilla.org/show_bug.cgi?id=1435826) are in progress in Firefox/SpiderMonkey
+- [Private instance fields](https://bugzilla.mozilla.org/show_bug.cgi?id=1562054) and [private instance methods and accessors](https://bugzilla.mozilla.org/show_bug.cgi?id=1435826) tracking issues in Firefox/SpiderMonkey Bugzilla
 - [Additional tooling support](https://github.com/tc39/proposal-class-fields/issues/57)
 
 ### Activity welcome in this repository

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ You can experiment with the class fields proposal using the following complete i
 - Public fields are [enabled by default](https://www.chromestatus.com/feature/6001727933251584) in Chrome 72 / V8 7.2
 - Private fields are [enabled by default](https://www.chromestatus.com/feature/6035156464828416) in Chrome 74 / V8 7.4
 - Public instance fields are [enabled by default](https://bugzilla.mozilla.org/show_bug.cgi?id=1499448) in Firefox 69
+- Public static fields are [enabled](https://bugzilla.mozilla.org/show_bug.cgi?id=1535804) in Firefox 75
 - [Moddable XS](https://blog.moddable.com/blog/secureprivate/)
 - [QuickJS](https://www.freelists.org/post/quickjs-devel/New-release,82)
 - [TypeScript 3.8](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#ecmascript-private-fields)
@@ -225,7 +226,7 @@ You can experiment with the class fields proposal using the following complete i
 Further implementations are on the way:
 
 - [Out for review](https://bugs.webkit.org/show_bug.cgi?id=174212) in Safari/JSC
-- [In progress](https://bugzilla.mozilla.org/show_bug.cgi?id=1499448) in Firefox/SpiderMonkey
+- [Private instance fields](https://bugzilla.mozilla.org/show_bug.cgi?id=1562054) and [private instance methods and accessors](https://bugzilla.mozilla.org/show_bug.cgi?id=1435826) are in progress in Firefox/SpiderMonkey
 - [Additional tooling support](https://github.com/tc39/proposal-class-fields/issues/57)
 
 ### Activity welcome in this repository


### PR DESCRIPTION
Updated the status for public static fields, private instance fields and private instance methods and accessor. I [can't find a Bugzilla bug for static private class fields](https://bugzilla.mozilla.org/show_bug.cgi?id=1535804#c18), can add it later.