### PR TITLE
Communicate infallibility of invocation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1695,7 +1695,7 @@ emu-example pre {
     <h1>MakePrivateReference ( _baseValue_, _privateIdentifier_ )</h1>
     <emu-alg>
       1. Let _env_ be the running execution context's PrivateEnvironment.</ins>
-      1. Let _privateNameBinding_ be ? ResolveBinding(_privateIdentifier_, _env_).</ins>
+      1. Let _privateNameBinding_ be ! ResolveBinding(_privateIdentifier_, _env_).</ins>
       1. Let _privateName_ be GetValue(_privateNameBinding_).
       1. Assert: _privateName_ is a Private Name.
       1. Return a value of type Reference whose base value is _baseValue_, whose referenced name is _privateName_, whose strict reference flag is *true*.


### PR DESCRIPTION
Invoking ResolveBinding with a PrivateEnvironment can never result in an
abrupt completion because every environment in the "chain" of
PrivateEnvironments is a declarative environment, and HasBinding for
declarative environments never returns an abrupt completion.